### PR TITLE
Reduce complexity of config structure

### DIFF
--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -2,9 +2,11 @@
 name: example
 
 watcher:
-  time:
+  type: time
+  config:
     poll_seconds: 1
 
 executioner:
-  log:
-    tag: example
+  type: log
+  config:
+   tag: example

--- a/internal/goverseer/config/config.go
+++ b/internal/goverseer/config/config.go
@@ -16,24 +16,6 @@ type WatcherConfig struct {
 	Config interface{}
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface for WatcherConfig
-// Because we want to have the type parsed from the yaml node rather than having
-// to specify a watcher.type node in the config we need custom unmarshalling
-func (d *WatcherConfig) UnmarshalYAML(value *yaml.Node) error {
-	var raw map[string]interface{}
-	if err := value.Decode(&raw); err != nil {
-		return err
-	}
-
-	for k, v := range raw {
-		d.Type = k
-		d.Config = v
-		break
-	}
-
-	return nil
-}
-
 // ExecutionerConfig is a custom type that handles dynamic unmarshalling
 type ExecutionerConfig struct {
 	// Type is the type of executioner
@@ -42,24 +24,6 @@ type ExecutionerConfig struct {
 	// Config is the configuration for the watcher
 	// The config values will be parsed by the watcher
 	Config interface{}
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for WatcherConfig
-// Because we want to have the type parsed from the yaml node rather than having
-// to specify a watcher.type node in the config we need custom unmarshalling
-func (d *ExecutionerConfig) UnmarshalYAML(value *yaml.Node) error {
-	var raw map[string]interface{}
-	if err := value.Decode(&raw); err != nil {
-		return err
-	}
-
-	for k, v := range raw {
-		d.Type = k
-		d.Config = v
-		break
-	}
-
-	return nil
 }
 
 // Config is the configuration for a watcher and executioner

--- a/internal/goverseer/config/config_test.go
+++ b/internal/goverseer/config/config_test.go
@@ -14,10 +14,12 @@ const (
 	testConfigWatcherToLog = `
 name: WatcherToLog
 watcher:
-  time:
+  type: time
+  config:
     poll_seconds: 1
 executioner:
-  log:
+  type: log
+  config:
     tag: test
 `
 )


### PR DESCRIPTION
[INF-5526](https://simplifi.atlassian.net/browse/INF-5526)
---

There really wasn't much point in using a config structure of:
```yaml
watcher:
  time:
    poll_seconds: 1
```

Instead of:
```yaml
watcher:
  type: time
  config:
    poll_seconds: 1
```

It saved 1 line in the config, but added like 30 lines of code to support it. Before we get locked-in to this config structure I figured I'd clean it up.

[INF-5526]: https://simplifi.atlassian.net/browse/INF-5526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ