### PR TITLE
DRY up the configs a bit

### DIFF
--- a/internal/goverseer/executioner/log_executioner/log_executioner.go
+++ b/internal/goverseer/executioner/log_executioner/log_executioner.go
@@ -13,20 +13,20 @@ const (
 )
 
 // LogExecutionerConfig is the configuration for a log executioner
-type LogExecutionerConfig struct {
+type Config struct {
 	// Tag is a tag to add to the logs, by default it is empty
 	Tag string
 }
 
 // ParseConfig parses the config for a log executioner
 // It validates the config, sets defaults if missing, and returns the config
-func ParseConfig(config interface{}) (*LogExecutionerConfig, error) {
+func ParseConfig(config interface{}) (*Config, error) {
 	cfgMap, ok := config.(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid config")
 	}
 
-	lec := &LogExecutionerConfig{
+	lec := &Config{
 		Tag: DefaultTag,
 	}
 
@@ -40,6 +40,8 @@ func ParseConfig(config interface{}) (*LogExecutionerConfig, error) {
 // LogExecutioner logs the data to stdout
 // It implements the Executioner interface
 type LogExecutioner struct {
+	Config
+
 	// log is the logger
 	log *slog.Logger
 }

--- a/internal/goverseer/executioner/shell_executioner/shell_executioner.go
+++ b/internal/goverseer/executioner/shell_executioner/shell_executioner.go
@@ -22,8 +22,8 @@ const (
 	DefaultShell = "/bin/sh"
 )
 
-// ShellExecutionerConfig is the configuration for a shell executioner
-type ShellExecutionerConfig struct {
+// Config is the configuration for a shell executioner
+type Config struct {
 	// Command is the command to execute
 	Command string
 
@@ -33,13 +33,13 @@ type ShellExecutionerConfig struct {
 
 // ParseConfig parses the config for a log executioner
 // It validates the config, sets defaults if missing, and returns the config
-func ParseConfig(config interface{}) (*ShellExecutionerConfig, error) {
+func ParseConfig(config interface{}) (*Config, error) {
 	cfgMap, ok := config.(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid config")
 	}
 
-	cfg := &ShellExecutionerConfig{
+	cfg := &Config{
 		Shell: DefaultShell,
 	}
 
@@ -73,11 +73,7 @@ func ParseConfig(config interface{}) (*ShellExecutionerConfig, error) {
 // ShellExecutioner runs a shell command
 // It implements the Executioner interface
 type ShellExecutioner struct {
-	// Command is the command to execute
-	Command string
-
-	// Shell is the shell to use when executing the command
-	Shell string
+	Config
 
 	// workDir is the directory in which the ShellExecutioner will store
 	// the command to run and the data to pass into the command
@@ -112,8 +108,10 @@ func New(cfg config.Config, log *slog.Logger) (*ShellExecutioner, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &ShellExecutioner{
-		Command: pcfg.Command,
-		Shell:   pcfg.Shell,
+		Config: Config{
+			Command: pcfg.Command,
+			Shell:   pcfg.Shell,
+		},
 		workDir: workDir,
 		log:     log,
 		stop:    make(chan struct{}),

--- a/internal/goverseer/executioner/shell_executioner/shell_executioner_test.go
+++ b/internal/goverseer/executioner/shell_executioner/shell_executioner_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
-	var parsedConfig *ShellExecutionerConfig
+	var parsedConfig *Config
 
 	parsedConfig, err := ParseConfig(map[string]interface{}{
 		"command": "echo 123",
@@ -125,8 +125,10 @@ func TestShellExecutioner_Execute(t *testing.T) {
 	tempDir, _ := os.MkdirTemp("", "goverseer-test")
 	ctx, cancel := context.WithCancel(context.Background())
 	executioner := ShellExecutioner{
-		Command: "echo ${GOVERSEER_DATA}",
-		Shell:   DefaultShell,
+		Config: Config{
+			Command: "echo ${GOVERSEER_DATA}",
+			Shell:   DefaultShell,
+		},
 		workDir: tempDir,
 		log:     log,
 		stop:    make(chan struct{}),
@@ -144,8 +146,10 @@ func TestShellExecutioner_Stop(t *testing.T) {
 	tempDir, _ := os.MkdirTemp("", "goverseer-test")
 	ctx, cancel := context.WithCancel(context.Background())
 	executioner := ShellExecutioner{
-		Command: "for i in {1..1000}; do echo $i; sleep 1; done",
-		Shell:   DefaultShell,
+		Config: Config{
+			Command: "for i in {1..1000}; do echo $i; sleep 1; done",
+			Shell:   DefaultShell,
+		},
 		workDir: tempDir,
 		log:     log,
 		stop:    make(chan struct{}),

--- a/internal/goverseer/watcher/file_watcher/file_watcher_test.go
+++ b/internal/goverseer/watcher/file_watcher/file_watcher_test.go
@@ -35,7 +35,7 @@ func touchFile(t *testing.T, filename string) {
 }
 
 func TestParseConfig(t *testing.T) {
-	var parsedConfig *FileWatcherConfig
+	var parsedConfig *Config
 	var err error
 
 	parsedConfig, err = ParseConfig(map[string]interface{}{
@@ -172,11 +172,13 @@ func TestFileWatcher_Stop(t *testing.T) {
 	touchFile(t, testFilePath)
 
 	watcher := FileWatcher{
-		Path:         testFilePath,
-		PollInterval: 1 * time.Second,
-		lastValue:    time.Now(),
-		log:          log,
-		stop:         make(chan struct{}),
+		Config: Config{
+			Path:        testFilePath,
+			PollSeconds: 1,
+		},
+		lastValue: time.Now(),
+		log:       log,
+		stop:      make(chan struct{}),
 	}
 
 	changes := make(chan interface{})

--- a/internal/goverseer/watcher/gce_metadata_watcher/gce_metadata_watcher_test.go
+++ b/internal/goverseer/watcher/gce_metadata_watcher/gce_metadata_watcher_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestParseConfig tests the ParseConfig function
 func TestParseConfig(t *testing.T) {
-	var parsedConfig *GceMetadataWatcherConfig
+	var parsedConfig *Config
 
 	testKey := "valid"
 	parsedConfig, err := ParseConfig(map[string]interface{}{
@@ -203,13 +203,15 @@ func TestGceMetadataWatcher_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	watcher := GceMetadataWatcher{
-		Key:               "test",
-		Recursive:         true,
-		MetadataUrl:       mockServer.URL,
-		MetadataErrorWait: 1 * time.Second,
-		log:               log,
-		ctx:               ctx,
-		cancel:            cancel,
+		Config: Config{
+			Key:                      "test",
+			Recursive:                true,
+			MetadataUrl:              mockServer.URL,
+			MetadataErrorWaitSeconds: 1,
+		},
+		log:    log,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 
 	changes := make(chan interface{})
@@ -253,13 +255,15 @@ func TestGceMetadataWatcher_Stop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	watcher := GceMetadataWatcher{
-		Key:               "test",
-		Recursive:         true,
-		MetadataUrl:       mockServer.URL,
-		MetadataErrorWait: 1 * time.Second,
-		log:               log,
-		ctx:               ctx,
-		cancel:            cancel,
+		Config: Config{
+			Key:                      "test",
+			Recursive:                true,
+			MetadataUrl:              mockServer.URL,
+			MetadataErrorWaitSeconds: 1,
+		},
+		log:    log,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 
 	changes := make(chan interface{})

--- a/internal/goverseer/watcher/time_watcher/time_watcher_test.go
+++ b/internal/goverseer/watcher/time_watcher/time_watcher_test.go
@@ -67,7 +67,7 @@ func TestTimeWatcher_Watch(t *testing.T) {
 	// Create a new TimeWatcher
 	watcher, err := New(cfg, log)
 	assert.NoError(t, err)
-	t.Log(watcher.PollInterval)
+	t.Log(watcher.PollSeconds)
 	// Start watching the file
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
Updating a config requires you to make changes in multiple places. This PR DRYs that up a bit by embedding the config structs. 

This has no functional change to behavior, just an improvement for maintaining this.