### PR TITLE
Rework the WorkDir and Persistance in ShellExecutioner

### DIFF
--- a/docs/executioners/shell_executioner.md
+++ b/docs/executioners/shell_executioner.md
@@ -16,6 +16,12 @@ file. The following configuration options are available:
   `echo "Data received: $GOVERSEER_DATA"`.
 - `shell`: (Optional) This specifies the shell to use for executing the command.
   Defaults to `/bin/sh` if not provided.
+- `work_dir`: (Optional) This specifies the directory where the executioner
+  stores the data file. Defaults to the `/tmp` if not provided.
+- `persist_data`: (Optional) This determines whether the command and data will
+  persist after completion. This can be useful to enable when troubleshooting
+  configured commands but should generally remain disabled otherwise. Defaults
+  to `false` if not provided.
 
 **Example Configuration:**
 

--- a/internal/goverseer/executioner/shell_executioner/shell_executioner_test.go
+++ b/internal/goverseer/executioner/shell_executioner/shell_executioner_test.go
@@ -2,6 +2,7 @@ package shell_executioner
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -170,6 +171,27 @@ func TestShellExecutioner_Execute(t *testing.T) {
 	err := executioner.Execute("test_data")
 	assert.NoError(t, err,
 		"Executing a valid command should not return an error")
+
+	// This tests to ensure the workdir is still available after cleanup has run
+	// for the first time
+	err = executioner.Execute("test_data")
+	assert.NoError(t, err,
+		"Executing a valid command multiple times should not return an error")
+
+	// Test data persistance
+
+	testWorkDir := t.TempDir()
+	executioner.PersistData = true
+	executioner.WorkDir = testWorkDir
+
+	err = executioner.Execute("test_persistence")
+	assert.NoError(t, err,
+		"Executing a command with PersistData should not return an error")
+
+	dirs, _ := os.ReadDir(testWorkDir)
+	t.Logf("Dirs: %v", dirs)
+	assert.GreaterOrEqual(t, len(dirs), 1,
+		"Executing a command with PersistData should persist the data")
 }
 
 func TestShellExecutioner_Stop(t *testing.T) {


### PR DESCRIPTION
Reworking the ShellExecutioner to make it possible to persist the data that triggered an execution. This can be helpful when troubleshooting a shell command.

I also discovered a bug where multiple executions would result in failures due to the workdir not existing. The ShellExecutioner was creating the directory when `New` was called, and it was removing it in `Execute` (without recreating). There is really no need to create the directory inside of `New` so I moved the creation and cleanup into `Execute` instead.

Tests have been added for the bug and also the new functionality `PersistData`.