### PR TITLE
Fixes for ShellExecutioner

### DIFF
--- a/docs/executioners/shell_executioner.md
+++ b/docs/executioners/shell_executioner.md
@@ -12,7 +12,7 @@ command via an environment variable named `GOVERSEER_DATA`.
 To use the Shell Executioner, you need to configure it in your Goverseer config
 file. The following configuration options are available:
 
-- `command`: This is the shell command you want to execute.For example,
+- `command`: This is the shell command you want to execute. For example,
   `echo "Data received: $GOVERSEER_DATA"`.
 - `shell`: (Optional) This specifies the shell to use for executing the command.
   Defaults to `/bin/sh -ec` if not provided.

--- a/docs/executioners/shell_executioner.md
+++ b/docs/executioners/shell_executioner.md
@@ -15,7 +15,7 @@ file. The following configuration options are available:
 - `command`: This is the shell command you want to execute.For example,
   `echo "Data received: $GOVERSEER_DATA"`.
 - `shell`: (Optional) This specifies the shell to use for executing the command.
-  Defaults to `/bin/sh` if not provided.
+  Defaults to `/bin/sh -ec` if not provided.
 - `work_dir`: (Optional) This specifies the directory where the executioner
   stores the data file. Defaults to the `/tmp` if not provided.
 - `persist_data`: (Optional) This determines whether the command and data will
@@ -34,8 +34,9 @@ watcher:
 executioner:
   type: shell
   config:
-    command: echo "Data received: $GOVERSEER_DATA"
-    shell: /bin/bash
+    shell: /bin/bash -euo pipefail -c
+    command: |
+      echo "Data received: $GOVERSEER_DATA"
 ```
 
 **Note:**

--- a/internal/goverseer/executioner/shell_executioner/shell_executioner_test.go
+++ b/internal/goverseer/executioner/shell_executioner/shell_executioner_test.go
@@ -35,6 +35,15 @@ func TestParseConfig(t *testing.T) {
 
 	parsedConfig, err = ParseConfig(map[string]interface{}{
 		"command": "echo 123",
+		"shell":   "/bin/bash -euo pipefail -c",
+	})
+	assert.NoError(t, err,
+		"Parsing a config with shell options not return an error")
+	assert.Equal(t, "/bin/bash -euo pipefail -c", parsedConfig.Shell,
+		"Shell should be set to the value in the config")
+
+	parsedConfig, err = ParseConfig(map[string]interface{}{
+		"command": "echo 123",
 		"shell":   nil,
 	})
 	assert.NoError(t, err,
@@ -178,8 +187,13 @@ func TestShellExecutioner_Execute(t *testing.T) {
 	assert.NoError(t, err,
 		"Executing a valid command multiple times should not return an error")
 
-	// Test data persistance
+	// Test shell options
+	executioner.Shell = "/bin/bash -euo pipefail -c"
+	err = executioner.Execute("test_shell_opts")
+	assert.NoError(t, err,
+		"Executing a command with shell options should not return an error")
 
+	// Test data persistance
 	testWorkDir := t.TempDir()
 	executioner.PersistData = true
 	executioner.WorkDir = testWorkDir

--- a/internal/goverseer/watcher/time_watcher/time_watcher.go
+++ b/internal/goverseer/watcher/time_watcher/time_watcher.go
@@ -67,7 +67,6 @@ func New(cfg config.Config) (*TimeWatcher, error) {
 }
 
 // Watch ticks at regular intervals, sending the time to the changes channel
-// The changes channel is where the path to the file is sent when it changes
 func (w *TimeWatcher) Watch(change chan interface{}) {
 	log.Info("starting watcher")
 	for {
@@ -76,7 +75,7 @@ func (w *TimeWatcher) Watch(change chan interface{}) {
 			return
 		case value := <-time.After(time.Duration(w.PollSeconds) * time.Second):
 			log.Info("time watcher tick", "value", value)
-			change <- value
+			change <- value.String()
 		}
 	}
 }

--- a/internal/goverseer/watcher/time_watcher/time_watcher_test.go
+++ b/internal/goverseer/watcher/time_watcher/time_watcher_test.go
@@ -76,6 +76,8 @@ func TestTimeWatcher_Watch(t *testing.T) {
 	select {
 	case value := <-changes:
 		assert.NotEmpty(t, value)
+		// assert that the value is a string
+		assert.IsType(t, "", value)
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "Timed out waiting for file change")
 	}


### PR DESCRIPTION
Some fixes for ShellExecutioner based on my experience using it more extensively.

* Resolving an issue where output pipe is still reading when the command completes, logging an error. This was caused by calling `.Close()` on the pipe instead of letting it close itself (as indicated in the documentation of os/exec).
* Enabling the ability to pass options for the shell
* Removing the need to write the command to disk before running it, this was unnecessary and just added more stuff to cleanup.
* Fixing log output of ShellExecutioner - prior to this a failed command's output would be logged as `INFO`. It now logs correctly as `ERROR`.
* Fixing bug where using the TimeWatcher to send data to ShellExecutioner causes a panic:
`panic: interface conversion: interface {} is time.Time, not string`. The change channel is `interface{}`, but I had always intended for this time value to be passed as a string.
