### PR TITLE
INF-6653 Address Error Message

### DIFF
--- a/internal/goverseer/watcher/gcp_secrets_watcher/gcp_secrets_watcher.go
+++ b/internal/goverseer/watcher/gcp_secrets_watcher/gcp_secrets_watcher.go
@@ -261,7 +261,7 @@ func (w *GcpSecretsWatcher) getSecretValue(projectID string) (string, error) {
 // Watches the GCP Secrets Manager for changes in ETag
 // and sends the new value to the changes channel
 func (w *GcpSecretsWatcher) Watch(change chan interface{}) {
-	logger.Log.Info("starting GCP Secrets Manager watcher for project: %s, secret: %s", w.ProjectID, w.SecretName)
+	logger.Log.Info("Starting GCP Secrets Manager watcher for project", w.ProjectID, "secret:", w.SecretName)
 
 	for {
 		select {


### PR DESCRIPTION
[Task](https://simplifi.atlassian.net/browse/INF-6653) that spurred the testing.

When doing some testing of the gcp-secrets-watcher Goverseer service, I saw a slight issue with the logged message formatting and wanted to address.