### PR TITLE
INF-5803 Adjust to use correct logging message

### DIFF
--- a/internal/goverseer/watcher/gcp_secrets_watcher/gcp_secrets_watcher.go
+++ b/internal/goverseer/watcher/gcp_secrets_watcher/gcp_secrets_watcher.go
@@ -261,7 +261,7 @@ func (w *GcpSecretsWatcher) getSecretValue(projectID string) (string, error) {
 // Watches the GCP Secrets Manager for changes in ETag
 // and sends the new value to the changes channel
 func (w *GcpSecretsWatcher) Watch(change chan interface{}) {
-	logger.Log.Info("starting GCP Secrets Manager watcher for project: %s, secret: %s", w.ProjectID, w.SecretName)
+	logger.Log.Info("starting GCP Secrets Manager watcher", "project", w.ProjectID, "secret", w.SecretName)
 
 	for {
 		select {


### PR DESCRIPTION
[Task](https://simplifi.atlassian.net/browse/INF-5803)

While looking at logs in a test instance that is using this new goverseer, I noticed I must have missed a logging format change. This needs to utilize key-value pairs since it is using Logger.Log.Info and not fmt.